### PR TITLE
Implementa bandeira de alerta e reorganiza footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,11 @@
         <h1>Calculadora de Rinossinusite Bacteriana Aguda</h1>
         <p class="subtitle">Baseada nos critérios do EPOS 2020</p>
 
-        <div class="red-flags-group">
+        <div id="red-flag-icon" title="Sinais de alerta">
+            <i class="fas fa-flag"></i>
+        </div>
+
+        <div class="red-flags-group" id="red-flags-panel">
             <h2><i class="fas fa-exclamation-triangle"></i> Sinais de Alarme (Red Flags)</h2>
             <p>A presença de QUALQUER um dos seguintes sinais requer encaminhamento IMEDIATO para avaliação especializada/emergência:</p>
             <ul>
@@ -62,11 +66,11 @@
         <footer>
             <p><strong>Aviso:</strong> Esta ferramenta é um auxílio para a decisão clínica baseada nas diretrizes do EPOS 2020 e não substitui o julgamento clínico profissional. A avaliação completa do paciente é essencial.</p>
             <p>Referência: Fokkens WJ, Lund VJ, Hopkins C, et al. European Position Paper on Rhinosinusitis and Nasal Polyps 2020. Rhinology. 2020;58(Suppl S29):1-464.</p>
+            <p class="author">Criado por Dr. Dario Hart</p>
         </footer>
     </div>
 
     <script src="script.js"></script>
     <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
-    <footer>Criado por Dr. Dario Hart</footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -18,3 +18,14 @@
                 resultDiv.classList.add('result-unlikely');
             }
         });
+
+        const flagIcon = document.getElementById('red-flag-icon');
+        const flagsPanel = document.getElementById('red-flags-panel');
+
+        function showFlags() {
+            flagsPanel.style.display = 'block';
+        }
+
+        flagIcon.addEventListener('click', showFlags);
+        flagIcon.addEventListener('mouseenter', showFlags);
+        flagIcon.addEventListener('touchstart', showFlags);

--- a/style.css
+++ b/style.css
@@ -31,7 +31,8 @@
             text-align: center;
             color: #555;
             margin-bottom: 30px;
-            font-size: 0.9em;
+            font-size: 1.1em;
+            font-weight: 600;
         }
 
        .criteria-group,.red-flags-group {
@@ -141,11 +142,23 @@
             color: #c62828;
         }
 
-        footer {
-            margin-top: 30px;
+       footer {
+           margin-top: 30px;
+           text-align: center;
+           font-size: 0.8em;
+           color: #777;
+       }
+
+       #red-flag-icon {
+            color: #c62828;
+            font-size: 1.5em;
+            cursor: pointer;
             text-align: center;
-            font-size: 0.8em;
-            color: #777;
+            margin-bottom: 10px;
+        }
+
+       #red-flags-panel {
+            display: none;
         }
 
 /* Small screen adjustments */


### PR DESCRIPTION
## Summary
- coloca creditos de autoria dentro do footer principal
- adiciona ícone de bandeira vermelha que revela o painel de alertas
- ajusta subtítulo e estilos para consistência
- oculta painel de alertas até interação

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881dfd0ae90832b8eee81bd15b99726