### PR TITLE
Implement color palette and add reset/print features

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
         <h1>Calculadora de Rinossinusite Bacteriana Aguda</h1>
         <p class="subtitle">Baseada nos critérios do EPOS 2020</p>
         <button id="help-btn">Ajuda</button>
+        <button id="prescriptions-btn">Recomendações de Antibiótico</button>
         <div id="help-section">
             <h2>Como usar</h2>
             <p>Selecione os sinais e sintomas de acordo com o EPOS 2020 e clique em "Calcular Probabilidade".</p>
@@ -67,9 +68,20 @@
 
         <div class="btn-container">
             <button id="calculate-btn">Calcular Probabilidade</button>
+            <button id="reset-btn">Resetar</button>
+        </div>
+
+        <div class="btn-container" id="print-container">
+            <button id="print-btn">Imprimir Resultado</button>
         </div>
 
         <div id="result"></div>
+
+        <div id="prescriptions-section">
+            <h2>Prescrições e Recomendações de Antibióticos</h2>
+            <p id="antibiotic-content">Conteúdo será adicionado futuramente.</p>
+            <button id="back-btn">Voltar ao Teste</button>
+        </div>
 
         <footer>
             <p><strong>Aviso:</strong> Esta ferramenta é um auxílio para a decisão clínica baseada nas diretrizes do EPOS 2020 e não substitui o julgamento clínico profissional. A avaliação completa do paciente é essencial.</p>

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@
             // Get all checkboxes with the name 'criteria'
             const criteria = document.querySelectorAll('input[name="criteria"]:checked');
             const score = criteria.length;
-            
+
             const resultDiv = document.getElementById('result');
             
             // Reset previous results
@@ -17,6 +17,7 @@
                 resultDiv.innerHTML = `<strong>Resultado: RSAB Pouco Provável (Pontuação: ${score})</strong><br>O quadro é mais consistente com Rinossinusite Viral ou Pós-Viral. A antibioterapia não é recomendada. Sugere-se tratamento sintomático.`;
                 resultDiv.classList.add('result-unlikely');
             }
+            printBtn.style.display = 'inline-block';
         });
 
         const helpBtn = document.getElementById('help-btn');
@@ -40,3 +41,33 @@
         flagIcon.addEventListener('click', showFlags);
         flagIcon.addEventListener('mouseenter', showFlags);
         flagIcon.addEventListener('touchstart', showFlags);
+
+        const resetBtn = document.getElementById('reset-btn');
+        const printBtn = document.getElementById('print-btn');
+        const prescriptionsBtn = document.getElementById('prescriptions-btn');
+        const backBtn = document.getElementById('back-btn');
+        const prescriptionsSection = document.getElementById('prescriptions-section');
+        const mainContainer = document.querySelector('.container');
+
+        resetBtn.addEventListener('click', function() {
+            document.querySelectorAll('input[name="criteria"]').forEach(cb => cb.checked = false);
+            resultDiv.style.display = 'none';
+            resultDiv.classList.remove('result-unlikely', 'result-likely');
+            resultDiv.innerHTML = '';
+            printBtn.style.display = 'none';
+        });
+
+        printBtn.addEventListener('click', function() {
+            window.print();
+        });
+
+        prescriptionsBtn.addEventListener('click', function() {
+            document.getElementById('result').scrollIntoView();
+            document.getElementById('result').style.display = 'none';
+            prescriptionsSection.style.display = 'block';
+        });
+
+        backBtn.addEventListener('click', function() {
+            prescriptionsSection.style.display = 'none';
+            resultDiv.style.display = 'block';
+        });

--- a/style.css
+++ b/style.css
@@ -1,9 +1,17 @@
         @import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap');
 
+        :root {
+            --cor-primaria: #63C1B2;
+            --cor-fundo: #F2F2F2;
+            --cor-texto-principal: #6F6F6F;
+            --cor-texto-secundario: #8C8C8C;
+            --cor-texto-contraste: #FFFFFF;
+        }
+
         body {
             font-family: 'Lato', sans-serif;
-            background-color: #f4f7f6;
-            color: #333;
+            background-color: var(--cor-fundo);
+            color: var(--cor-texto-principal);
             margin: 0;
             padding: 20px;
             display: flex;
@@ -22,14 +30,14 @@
         }
 
         h1 {
-            color: #005a9c;
+            color: var(--cor-texto-principal);
             text-align: center;
             margin-bottom: 10px;
         }
         
        .subtitle {
             text-align: center;
-            color: #555;
+            color: var(--cor-texto-secundario);
             margin-bottom: 30px;
             font-size: 1.1em;
             font-weight: 600;
@@ -40,7 +48,7 @@
         }
 
         h2 {
-            color: #005a9c;
+            color: var(--cor-primaria);
             border-bottom: 2px solid #e0e0e0;
             padding-bottom: 5px;
             margin-bottom: 15px;
@@ -75,11 +83,15 @@
        .btn-container {
             text-align: center;
             margin-top: 30px;
+       }
+
+       .btn-container button {
+            margin: 5px;
         }
 
-        button {
-            background-color: #007bff;
-            color: white;
+       button {
+            background-color: var(--cor-primaria);
+            color: var(--cor-texto-contraste);
             border: none;
             padding: 15px 30px;
             font-size: 1.2em;
@@ -89,18 +101,13 @@
         }
 
        button:hover {
-            background-color: #0056b3;
+            background-color: #4fa79b;
             transform: translateY(-2px);
         }
 
        /* Help button and panel */
        #help-btn {
-            margin-bottom: 15px;
-            background-color: #28a745;
-       }
-
-       #help-btn:hover {
-            background-color: #218838;
+            margin: 0 auto 15px auto;
        }
 
        #help-section {
@@ -112,6 +119,20 @@
             margin-bottom: 20px;
             font-size: 0.9em;
        }
+
+       #prescriptions-section {
+            display: none;
+            margin-top: 20px;
+        }
+
+       #print-container {
+            text-align: center;
+            margin-top: 15px;
+        }
+
+       #print-btn {
+            display: none;
+        }
 
         #result {
             margin-top: 30px;


### PR DESCRIPTION
## Summary
- apply new EPOS color palette and center the help button
- add reset and print buttons
- add placeholder antibiotic recommendations section
- show/hide antibiotic section and allow result printing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881e529fe4c832ba1ed39369a49da13