### PR TITLE
Implement toggle for flags panel

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,9 +38,22 @@
             flagsPanel.style.display = 'block';
         }
 
-        flagIcon.addEventListener('click', showFlags);
+        function toggleFlags() {
+            if (flagsPanel.style.display === 'block') {
+                flagsPanel.style.display = 'none';
+            } else {
+                flagsPanel.style.display = 'block';
+            }
+        }
+
+        function hideFlags() {
+            flagsPanel.style.display = 'none';
+        }
+
+        flagIcon.addEventListener('click', toggleFlags);
         flagIcon.addEventListener('mouseenter', showFlags);
-        flagIcon.addEventListener('touchstart', showFlags);
+        flagIcon.addEventListener('touchstart', toggleFlags);
+        flagsPanel.addEventListener('mouseleave', hideFlags);
 
         const resetBtn = document.getElementById('reset-btn');
         const printBtn = document.getElementById('print-btn');


### PR DESCRIPTION
## Summary
- add `toggleFlags` and `hideFlags` helpers in `script.js`
- update event listeners to use new toggle function
- close the panel when the cursor leaves it

## Testing
- `npx --yes prettier -w index.html script.js style.css` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886afb5ebfc832ba8afdce6fd0c946f