### PR TITLE
Fix reset and back logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -69,6 +69,7 @@
             resultDiv.classList.remove('result-unlikely', 'result-likely');
             resultDiv.innerHTML = '';
             printBtn.style.display = 'none';
+            prescriptionsSection.style.display = 'none';
         });
 
         printBtn.addEventListener('click', function() {
@@ -83,5 +84,7 @@
 
         backBtn.addEventListener('click', function() {
             prescriptionsSection.style.display = 'none';
-            resultDiv.style.display = 'block';
+            if (resultDiv.innerHTML.trim() !== '') {
+                resultDiv.style.display = 'block';
+            }
         });


### PR DESCRIPTION
## Summary
- hide prescriptions section when resetting the form
- only redisplay the results panel if a result exists

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6886c4175904832b9942a9bc2548a0f1