### PR TITLE
Update flag icon interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
             <p>Esta ferramenta serve apenas como guia e não substitui avaliação médica.</p>
         </div>
 
-        <div id="red-flag-icon" title="Sinais de alerta">
+        <div id="red-flag-icon" title="Clique na bandeira para ver os sinais de alarme">
             <i class="fas fa-flag">🚩</i>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -63,9 +63,15 @@
         }
 
         flagIcon.addEventListener('click', toggleFlags);
-        flagIcon.addEventListener('mouseenter', showFlags);
         flagIcon.addEventListener('touchstart', toggleFlags);
-        flagsPanel.addEventListener('mouseleave', hideFlags);
+
+        document.addEventListener('click', function(event) {
+            if (flagsPanel.style.display === 'block' &&
+                !flagsPanel.contains(event.target) &&
+                !flagIcon.contains(event.target)) {
+                hideFlags();
+            }
+        });
 
         const resetBtn = document.getElementById('reset-btn');
         const printBtn = document.getElementById('print-btn');


### PR DESCRIPTION
## Summary
- make red flag icon tooltip explain how to open alarm signs panel
- remove mouseenter logic and close red flags panel on outside click

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886de830bc0832b91313fe5dcfadcc9