### PR TITLE
Add width and centering to help/result sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -139,7 +139,7 @@
             display: none;
         }
 
-        #result {
+       #result {
             margin-top: 30px;
             padding: 20px;
             border-radius: 8px;
@@ -147,6 +147,12 @@
             font-size: 1.2em;
             font-weight: bold;
             display: none; /* Hidden by default */
+        }
+
+        #help-section,
+        #result {
+            max-width: 600px;
+            margin: 0 auto;
         }
 
        .result-unlikely {


### PR DESCRIPTION
## Summary
- center `#help-section` and `#result` with a max width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688817fa6f24832b8eb9e4c1fd6a00cd