### PR TITLE
Enhance red flags popup with overlay and transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,18 +26,22 @@
             <i class="fas fa-flag">🚩</i>
         </div>
 
-        <div class="red-flags-group" id="red-flags-panel">
-            <h2><i class="fas fa-exclamation-triangle"></i> Sinais de Alarme (Red Flags)</h2>
-            <p>A presença de QUALQUER um dos seguintes sinais requer encaminhamento IMEDIATO para avaliação especializada/emergência:</p>
-            <ul>
-                <li>- Edema ou vermelhidão periorbitária</li>
-                <li>- Deslocamento do globo ocular</li>
-                <li>- Visão dupla ou reduzida</li>
-                <li>- Oftalmoplegia (paralisia de músculos oculares)</li>
-                <li>- Dor de cabeça frontal severa</li>
-                <li>- Inchaço na região frontal</li>
-                <li>- Sinais de meningite ou défices neurológicos focais</li>
-            </ul>
+        <div id="red-flags-panel">
+            <div id="red-flags-overlay"></div>
+            <div class="red-flags-group">
+                <button id="close-flags" aria-label="Fechar">Fechar</button>
+                <h2><i class="fas fa-exclamation-triangle"></i> Sinais de Alarme (Red Flags)</h2>
+                <p>A presença de QUALQUER um dos seguintes sinais requer encaminhamento IMEDIATO para avaliação especializada/emergência:</p>
+                <ul>
+                    <li>- Edema ou vermelhidão periorbitária</li>
+                    <li>- Deslocamento do globo ocular</li>
+                    <li>- Visão dupla ou reduzida</li>
+                    <li>- Oftalmoplegia (paralisia de músculos oculares)</li>
+                    <li>- Dor de cabeça frontal severa</li>
+                    <li>- Inchaço na região frontal</li>
+                    <li>- Sinais de meningite ou défices neurológicos focais</li>
+                </ul>
+            </div>
         </div>
 
         <div class="criteria-group">

--- a/script.js
+++ b/script.js
@@ -47,28 +47,35 @@
 
         const flagIcon = document.getElementById('red-flag-icon');
         const flagsPanel = document.getElementById('red-flags-panel');
+        const flagsOverlay = document.getElementById('red-flags-overlay');
+        const closeFlagsBtn = document.getElementById('close-flags');
 
         function showFlags() {
-            flagsPanel.style.display = 'block';
-        }
-
-        function toggleFlags() {
-            if (flagsPanel.style.display === 'block') {
-                flagsPanel.style.display = 'none';
-            } else {
-                flagsPanel.style.display = 'block';
-            }
+            flagsPanel.classList.add('visible');
+            flagsOverlay.classList.add('visible');
         }
 
         function hideFlags() {
-            flagsPanel.style.display = 'none';
+            flagsPanel.classList.remove('visible');
+            flagsOverlay.classList.remove('visible');
+        }
+
+        function toggleFlags() {
+            if (flagsPanel.classList.contains('visible')) {
+                hideFlags();
+            } else {
+                showFlags();
+            }
         }
 
         flagIcon.addEventListener('click', toggleFlags);
         flagIcon.addEventListener('touchstart', toggleFlags);
+        closeFlagsBtn.addEventListener('click', hideFlags);
+        closeFlagsBtn.addEventListener('touchstart', hideFlags);
+        flagsOverlay.addEventListener('click', hideFlags);
 
         document.addEventListener('click', function(event) {
-            if (flagsPanel.style.display === 'block' &&
+            if (flagsPanel.classList.contains('visible') &&
                 !flagsPanel.contains(event.target) &&
                 !flagIcon.contains(event.target)) {
                 hideFlags();

--- a/style.css
+++ b/style.css
@@ -207,17 +207,56 @@
             margin-bottom: 10px;
         }
 
+#red-flags-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    z-index: 999;
+}
+
 #red-flags-panel {
-     display: none;
-     max-width: 600px;
-     width: 100%;
-     margin: 20px auto;
-     box-sizing: border-box;
-     position: fixed;
-     top: 50%;
-     left: 50%;
-     transform: translate(-50%, -50%);
- }
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+    max-width: 600px;
+    width: 100%;
+    margin: 20px auto;
+    box-sizing: border-box;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1000;
+}
+
+#red-flags-panel.visible {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+}
+
+#red-flags-overlay.visible {
+    visibility: visible;
+    opacity: 1;
+}
+
+#close-flags {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: #c62828;
+    font-weight: bold;
+    cursor: pointer;
+}
 
 /* Small screen adjustments */
 @media (max-width: 320px) {


### PR DESCRIPTION
## Summary
- add overlay and close button for red flags panel
- style overlay and panel for fade transitions
- toggle visibility with classes in script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68881d6d2344832b835cc309c9d2c51d