### PR TITLE
Improve button styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,25 +95,32 @@
         }
 
 
-       button {
+        button {
             background-color: var(--cor-primaria);
             color: var(--cor-texto-contraste);
             border: none;
-            padding: 15px 30px;
-            font-size: 1.2em;
+            padding: 12px 24px;
+            font-size: 1em;
             border-radius: 5px;
             cursor: pointer;
             transition: background-color 0.3s, transform 0.2s;
         }
 
-       button:hover {
+        button:hover {
             background-color: #4fa79b;
             transform: translateY(-2px);
+        }
+
+        button:active {
+            filter: brightness(0.95);
+            transform: scale(0.97);
         }
 
        /* Help button and panel */
        #help-btn {
             margin: 0 auto 15px auto;
+            background-color: #b3e5fc;
+            color: #000000;
        }
 
        #help-section {
@@ -134,6 +141,19 @@
 
        #print-btn {
             display: none;
+            background-color: #ffa726;
+        }
+
+       #calculate-btn {
+            background-color: var(--cor-primaria);
+        }
+
+       #prescriptions-btn {
+            background-color: #5c6bc0;
+        }
+
+       #reset-btn {
+            background-color: #e57373;
         }
 
        #result {


### PR DESCRIPTION
## Summary
- reduce default button size and add active feedback state
- color-code action buttons for clarity

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68881d72b778832b9350022c218969cd